### PR TITLE
:pencil2: Italic & bold typo fixes

### DIFF
--- a/jfrog-applications/jfrog-cli/cli-for-jfrog-security/authentication.md
+++ b/jfrog-applications/jfrog-cli/cli-for-jfrog-security/authentication.md
@@ -4,13 +4,13 @@ When used with Xray, JFrog CLI offers several means of authentication: JFrog CLI
 
 #### Authenticating with Username and Password
 
-To authenticate yourself using your Xray login credentials, either configure your credentials once using the\_jf c add\_command or provide the following option to each command.
+To authenticate yourself using your Xray login credentials, either configure your credentials once using the _**jf c add**_ command or provide the following option to each command.
 
 <table><thead><tr><th width="424.5">Command Option</th><th>Description</th></tr></thead><tbody><tr><td>--url</td><td>JFrog Xray API endpoint URL. It usually ends with /xray</td></tr><tr><td>--user</td><td>JFrog username</td></tr><tr><td>--password</td><td>JFrog password</td></tr></tbody></table>
 
 #### Authenticating with an Access Token
 
-To authenticate yourself using an Xray Access Token, either configure your Access Token once using the \_jf c add\_command or provide the following option to each command.
+To authenticate yourself using an Xray Access Token, either configure your Access Token once using the _**jf c add**_ command or provide the following option to each command.
 
 <table><thead><tr><th width="218.5">Command Option</th><th>Description</th></tr></thead><tbody><tr><td>--url</td><td>JFrog Xray API endpoint URL. It usually ends with /xray</td></tr><tr><td>--access-token</td><td>JFrog access token</td></tr></tbody></table>
 

--- a/jfrog-applications/jfrog-cli/cli-for-jfrog-security/scan-your-binaries.md
+++ b/jfrog-applications/jfrog-cli/cli-for-jfrog-security/scan-your-binaries.md
@@ -4,7 +4,7 @@ The [on-demand binary scanning](https://jfrog-staging-external.fluidtopics.net/r
 
 ### Scanning Files on the Local File System
 
-This **jf scan**\_ command scans files on the local file system with Xray.
+This _**jf scan**_ command scans files on the local file system with Xray.
 
 ***
 


### PR DESCRIPTION
3 typos fixed regarding italic & bold marks for commands.