### PR TITLE
Fix internal link and Frogbot typo

### DIFF
--- a/jfrog-applications/frogbot/README.md
+++ b/jfrog-applications/frogbot/README.md
@@ -9,12 +9,12 @@ JFrog Frogbot is a Git bot that scans your Git repositories for security vulnera
 1. It scans pull requests immediately after they are opened but before they are merged. This process notifies you if the pull request is about to introduce new vulnerabilities to your code. This unique capability ensures the code is scanned and can be fixed even before vulnerabilities are introduced into the codebase.
 2. It scans the Git repository periodically and creates pull requests with fixes for detected vulnerabilities.
 
-#### It supports the following Git providers:
+#### Frogbot supports the following Git providers:
 
 | ![GitHub](https://raw.githubusercontent.com/jfrog/frogbot/master/images/github-icon.png) GitHub | ![GitLab](https://raw.githubusercontent.com/jfrog/frogbot/master/images/gitlab-icon.png) GitLab | ![Azure](https://raw.githubusercontent.com/jfrog/frogbot/master/images/azure-devops-icon.png) Azure Repos | ![Bitbucket](https://raw.githubusercontent.com/jfrog/frogbot/master/images/bitbucket-icon.png) Bitbucket Server |
 | ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
 
-#### It supports the following package managers are:
+#### For SCA Scanning. Frogbot supports projects that use the following package managers:
 
 | ![Go](https://raw.githubusercontent.com/jfrog/frogbot/master/images/go-icon.png) Go         | ![Gradle](https://raw.githubusercontent.com/jfrog/frogbot/master/images/gradle-icon.png) Gradle | ![Maven](https://raw.githubusercontent.com/jfrog/frogbot/master/images/maven-icon.png) Maven | ![npm](https://raw.githubusercontent.com/jfrog/frogbot/master/images/npm-icon.png) npm       | ![Yarn](https://raw.githubusercontent.com/jfrog/frogbot/master/images/yarn-icon.png) Yarn       |
 | ------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |

--- a/jfrog-applications/jfrog-cli/cli-for-jfrog-artifactory.md
+++ b/jfrog-applications/jfrog-cli/cli-for-jfrog-artifactory.md
@@ -3052,7 +3052,7 @@ For integrating with Maven and Gradle, JFrog CLI uses the build-info-extractor j
 If you're using JFrog CLI on a machine which has no access to the internet, you can configure JFrog CLI to download these jar files from an Artifactory instance. Here's how to configure Artifactory and JFrog CLI to download the jars files.
 
 1. Create a remote Maven repository in Artifactory and name it **extractors**. When creating the repository, configure it to proxy [https://releases.jfrog.io/artifactory/oss-release-local](https://releases.jfrog.io/artifactory/oss-release-local)
-2. Make sure that this Artifactory server is known to JFrog CLI, using the [jfrog c show](https://jfrog.com/help/r/jfrog-cli/showing-the-configured-servers) command. If not, configure it using the [jfrog c add](https://jfrog.com/help/r/jfrog-cli/Adding-and-Editing-Configured-Servers) command.
+2. Make sure that this Artifactory server is known to JFrog CLI, using the [jfrog c show](https://docs.jfrog-applications.jfrog.io/jfrog-applications/jfrog-cli/configurations/jfrog-platform-configuration#showing-the-configured-servers) command. If not, configure it using the [jfrog c add](https://jfrog.com/help/r/jfrog-cli/Adding-and-Editing-Configured-Servers) command.
 3. Set the **JFROG\_CLI\_EXTRACTORS\_REMOTE** environment variable with the server ID of the Artifactory server you configured, followed by a slash, and then the name of the repository you created. For example _**my-rt-server/extractors**_
 
 ## Transferring Files Between Artifactory Servers


### PR DESCRIPTION
* Frogbot typo fix.
* Replace internal link referencing the old docs to reference the new docs site.