### PR TITLE
Frogbot - Updating documentations with latest 'install' command deprecation changes

### DIFF
--- a/jfrog-applications/frogbot/README.md
+++ b/jfrog-applications/frogbot/README.md
@@ -32,7 +32,7 @@ JFrog Frogbot is a Git bot that scans your Git repositories for security vulnera
 - Go
 - Gradle
 - Maven
-- npm
+- Npm
 - Yarn
 - .NET
 - NuGet

--- a/jfrog-applications/frogbot/frogbot-configuration.md
+++ b/jfrog-applications/frogbot/frogbot-configuration.md
@@ -4,18 +4,18 @@
 
 ### What is the frogbot-config.yml file?
 
-The frogbot-config.yml file includes configuration related to your projects, to help Frogbot scan your Git repositories.
+The **frogbot-config.yml** file encompasses project-related configurations used by Frogbot's scanning. This includes details about the repository's directory structure and may additionally encompass package manager commands necessary for Frogbot to list the project's dependencies.
 
 ### Is the frogbot-config.yml file mandatory?
 
-Not all projects require the **frogbot-config.yml** file, but any project can use it.
+No, the file isn't mandatory. In most cases, Frogbot can understand the structure of the projects in the repository and list the project's depedencies without the file.
 
-If your project doesn't use a **frogbot-config.yml** file, all of the configuration Frogbot requires\
+If your project doesn't use a **frogbot-config.yml** file, all the configuration Frogbot requires\
 should be provided as variables as part of the Frogbot workflows.
 
 ### How does the frogbot-config.yml file helps Frogbot scan the repository?
 
-When your Git repository includes multiple subprojects, and each subproject has its own descriptor file (package.json in the case of npm), Frogbot will attempt to detect these projects recursively and scan them. In cases where the detection is not accurate, you can use the **frogbot-config.yml** file to include the relative paths to the subprojects. Frogbot uses this configuration to scan each subproject separately. In the following example, there are two subprojects under `path/to/project-1` and `path/to/project-2`.
+Frogbot relies on the project's descriptor files, such as package.json and pom.xml, to identify the project's dependencies. It scans the repository for these descriptor files and utilizes the appropriate package manager, such as npm or Maven, to compile a list of dependencies for the project. If you desire manual control over the project structure or the package manager commands, you can achieve this by creating a **frogbot-config.yml** file. In the provided example, we outline two subprojects located at **path/to/project-1** and **path/to/project-2** for Frogbot to include in its scanning process.
 
 ```yaml
 - params:
@@ -30,8 +30,7 @@ When your Git repository includes multiple subprojects, and each subproject has 
             - path/to/npm/project-2
 ```
 
-Here's another example. Notice that we can specify our own download command with our own flags, although this is not mandatory.
-In case the project's dependencies needs to be resolved and no download command was provided, an automatic 'install' command will be executed according to the detected package manager.
+Here's another example. Notice that we specify a custom 'install' command here.
 
 ```yaml
 - params:

--- a/jfrog-applications/frogbot/frogbot-configuration.md
+++ b/jfrog-applications/frogbot/frogbot-configuration.md
@@ -30,7 +30,8 @@ When your Git repository includes multiple subprojects, and each subproject has 
             - path/to/npm/project-2
 ```
 
-Here's another example. Notice that projects which use the nuget client to download the dependencies, the download command needs to be specified.
+Here's another example. Notice that we can specify our own download command with our own flags, although this is not mandatory.
+In case the project's dependencies needs to be resolved and no download command was provided, an automatic 'install' command will be executed according to the detected package manager.
 
 ```yaml
 - params:
@@ -46,8 +47,6 @@ Here's another example. Notice that projects which use the nuget client to downl
           workingDirs:
             - path/to/.net/project
 ```
-
-See the full **frogbot-config.yml** structure here.
 
 ### Can one frogbot-config.yml file be used for multiple Git repositories?
 

--- a/jfrog-applications/frogbot/scan-repositories.md
+++ b/jfrog-applications/frogbot/scan-repositories.md
@@ -6,6 +6,8 @@ Frogbot scans your Git repositories periodically and automatically creates pull 
   
   ![](../.gitbook/assets/fix-pr.png)
 
+_**NOTE:**_: The pull request fix is presently unavailable for older NuGet projects that use the package.config file instead of the PackageReference syntax.
+
 #### Adding Security Alerts
 
 For GitHub repositories, issues that are found during Frogbot's periodic scans are also added to the [Security Alerts](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/managing-code-scanning-alerts-for-your-repository) view in the UI. 

--- a/jfrog-applications/frogbot/setup-frogbot-using-gitlab-ci.md
+++ b/jfrog-applications/frogbot/setup-frogbot-using-gitlab-ci.md
@@ -14,7 +14,6 @@ To install Frogbot on GitLab repositories using GitLab CI:
 
 **Important**
 
-* Set the **JF\_INSTALL\_DEPS\_CMD** variable below, or the **installCommand** property in your frogbot-config.yml file, if the project uses yarn 2, NuGet or .NET to download its dependencies
 * Make sure that either **JF\_USER** and **JF\_PASSWORD** or **JF\_ACCESS\_TOKEN** are set, **but not both**.
 
 ```yml

--- a/jfrog-applications/jfrog-cli/cli-for-jfrog-security/scan-your-source-code.md
+++ b/jfrog-applications/jfrog-cli/cli-for-jfrog-security/scan-your-source-code.md
@@ -27,9 +27,8 @@ This command also supports the following Advanced Scans with the **Advanced Secu
 
 **Note**
 
->
-
 * The **jf audit** command does not extract the internal content of the scanned dependencies. This means that if a package includes other vulnerable components bundled inside the binary, they may not be shown as part of the results. This is contrary to the **jf scan** command, which drills down into the package content.
+* To generate the dependency tree for scanning purposes, the system will execute an 'install' command on the project if it hasn't been executed previously.
 
 ***
 


### PR DESCRIPTION
All documentation was fixed according to the latest deprecation of 'install' command execution in Frogbot.
Notes were added to emphasize some side-effects of building a dependency tree in Audit flow