### PR TITLE
Update setup-frogbot-using-gitlab-ci.md

### DIFF
--- a/jfrog-applications/frogbot/setup-frogbot-using-gitlab-ci.md
+++ b/jfrog-applications/frogbot/setup-frogbot-using-gitlab-ci.md
@@ -200,13 +200,13 @@ frogbot-scan:
   script:
     # For Linux / MacOS runner:
     - |
-      getFrogbotScriptPath=$(if [ -z "$JF_RELEASES_REPO" ]; then echo "https://releases.jfrog.io"; else echo "${JF_URL}/artifactory/${JF_RELEASES_REPO}"; fi)
-      curl -fLg "$getFrogbotScriptPath/artifactory/frogbot/v2/[RELEASE]/getFrogbot.sh" | sh
+      getFrogbotScriptPath=$(if [ -z "$JF_RELEASES_REPO" ]; then echo "https://releases.jfrog.io/artifactory/frogbot"; else echo "${JF_URL}/artifactory/${JF_RELEASES_REPO}"; fi)
+      curl -fLg "$getFrogbotScriptPath/v2/[RELEASE]/getFrogbot.sh" | sh
       ./frogbot ${FROGBOT_CMD}
 
     # For Windows runner:
     # 
-    # - $getFrogbotScriptPath = $(if ([string]::IsNullOrEmpty($env:JF_RELEASES_REPO)) { "https://releases.jfrog.io" } else { "$($env:JF_URL)/artifactory/$($env:JF_RELEASES_REPO)" })
-    # - Invoke-WebRequest -Uri "$getFrogbotScriptPath/artifactory/frogbot/v2/[RELEASE]/getFrogbot.sh" -UseBasicParsing | ForEach-Object { & $_.Content }
+    # - $getFrogbotScriptPath = $(if ([string]::IsNullOrEmpty($env:JF_RELEASES_REPO)) { "https://releases.jfrog.io/artifactory/frogbot" } else { "$($env:JF_URL)/artifactory/$($env:JF_RELEASES_REPO)" })
+    # - Invoke-WebRequest -Uri "$getFrogbotScriptPath/v2/[RELEASE]/getFrogbot.sh" -UseBasicParsing | ForEach-Object { & $_.Content }
     # - .\frogbot ${FROGBOT_CMD}
 ```


### PR DESCRIPTION
getFrogbot.sh installation script URL for an Artifactory remote repository is incorrect. Adding the repository name to the official release path to support both cases.