### PR TITLE
Update Frogbot GitHub actions templates

### DIFF
--- a/jfrog-applications/frogbot/setup-frogbot-using-github-actions.md
+++ b/jfrog-applications/frogbot/setup-frogbot-using-github-actions.md
@@ -100,7 +100,7 @@ Example step utilizing OpenID Connect:
 ```yml
 - uses: jfrog/frogbot@v2
   env:
-      JF_URL: ${{ secrets.JF_URL }}
+      JF_URL: ${{ vars.JF_URL }}
       JF_GIT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   with:
       oidc-provider-name: frogbot-integration

--- a/jfrog-applications/frogbot/templates/github-actions/frogbot-scan-pull-request.yml
+++ b/jfrog-applications/frogbot/templates/github-actions/frogbot-scan-pull-request.yml
@@ -18,7 +18,7 @@ jobs:
         env:
           # [Mandatory]
           # JFrog platform URL
-          JF_URL: ${{ secrets.JF_URL }}
+          JF_URL: ${{ vars.JF_URL }}
 
           # [Mandatory if JF_USER and JF_PASSWORD are not provided]
           # JFrog access token with 'read' permissions on Xray service

--- a/jfrog-applications/frogbot/templates/github-actions/frogbot-scan-repository.yml
+++ b/jfrog-applications/frogbot/templates/github-actions/frogbot-scan-repository.yml
@@ -22,7 +22,7 @@ jobs:
         env:
           # [Mandatory]
           # JFrog platform URL
-          JF_URL: ${{ secrets.JF_URL }}
+          JF_URL: ${{ vars.JF_URL }}
 
           # [Mandatory if JF_USER and JF_PASSWORD are not provided]
           # JFrog access token with 'read' permissions on Xray service


### PR DESCRIPTION
Update Frogbot's GitHub actions templates to use `JF_URL` as var instead of a secret.
This will allow the GitHub job summaries to display unmasked platform links in the summary